### PR TITLE
Support migrating NFS blob to Azure store account.

### DIFF
--- a/blobstore/azblob.go
+++ b/blobstore/azblob.go
@@ -1,0 +1,328 @@
+// Copyright 2017-Present Pivotal Software, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http:#www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blobstore
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/cheggaaa/pb"
+	"github.com/pivotal-cf/goblob/validation"
+
+	"github.com/Azure/azure-storage-blob-go/2018-03-28/azblob"
+)
+
+var (
+	containers              = []string{"cc-buildpacks", "cc-droplets", "cc-packages", "cc-resources"}
+	cloudStorageEnpointsMap = map[string]string{
+		"AzureChinaCloud":   "core.chinacloudapi.cn",
+		"AzureCloud":        "core.windows.net",
+		"AzureGermanCloud":  "core.cloudapi.de",
+		"AzureUSGovernment": "core.usgovcloudapi.net",
+	}
+)
+
+type azblobStore struct {
+	serviceURL          *azblob.ServiceURL
+	useMultipartUploads bool
+	containerMapping    map[string]string
+}
+
+func NewAzBlobStore(
+	accountName string,
+	accountKey string,
+	cloudName string,
+	buildpacksContainerName string,
+	dropletsContainerName string,
+	packagesContainerName string,
+	resourcesContainerName string,
+) Blobstore {
+	credential := azblob.NewSharedKeyCredential(accountName, accountKey)
+	pipeline := azblob.NewPipeline(credential, azblob.PipelineOptions{})
+
+	primaryURL, _ := url.Parse(
+		fmt.Sprintf("https://%s.blob.%s", accountName, cloudStorageEnpointsMap[cloudName]))
+	serviceURL := azblob.NewServiceURL(*primaryURL, pipeline)
+
+	return &azblobStore{
+		serviceURL: &serviceURL,
+		containerMapping: map[string]string{
+			"cc-buildpacks": buildpacksContainerName,
+			"cc-resources":  resourcesContainerName,
+			"cc-droplets":   dropletsContainerName,
+			"cc-packages":   packagesContainerName,
+		},
+	}
+}
+
+func (s *azblobStore) Name() string {
+	return "azure blob store"
+}
+
+func (s *azblobStore) List() ([]*Blob, error) {
+	var blobs []*Blob
+
+	containersOnAccount, err := s.listContainers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range containers {
+		containerName := s.destContainerName(container)
+		containerUrl := s.serviceURL.NewContainerURL(containerName)
+
+		containerExists := stringInArray(containersOnAccount, containerName)
+		if containerExists {
+			for marker := (azblob.Marker{}); marker.NotDone(); {
+				listBlob, err := containerUrl.ListBlobsFlatSegment(context.Background(),
+					marker,
+					azblob.ListBlobsSegmentOptions{})
+				if err != nil {
+					return nil, err
+				}
+
+				marker = listBlob.NextMarker
+
+				bar := pb.StartNew(len(listBlob.Segment.BlobItems))
+				for _, blobInfo := range listBlob.Segment.BlobItems {
+					md5, err := base64.StdEncoding.DecodeString(string(blobInfo.Properties.ContentMD5[:]))
+					if err != nil {
+						return nil, err
+					}
+					checksum := hex.EncodeToString(md5)
+
+					blob := &Blob{
+						Path:     filepath.Join(container, blobInfo.Name),
+						Checksum: checksum,
+					}
+					blobs = append(blobs, blob)
+
+					bar.Increment()
+				}
+				bar.FinishPrint(containerName)
+			}
+		}
+	}
+	return blobs, nil
+}
+
+func (s *azblobStore) Read(src *Blob) (io.ReadCloser, error) {
+	containerName := s.containerName(src)
+	path := s.path(src)
+
+	containerURL := s.serviceURL.NewContainerURL(containerName)
+	blobURL := containerURL.NewBlockBlobURL(path)
+	response, err := blobURL.Download(context.Background(),
+		0,
+		azblob.CountToEnd,
+		azblob.BlobAccessConditions{},
+		false)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Body(azblob.RetryReaderOptions{MaxRetryRequests: 3}), nil
+}
+
+func (s *azblobStore) Checksum(src *Blob) (string, error) {
+	// large blob does not have Content-MD5 in Metadata,
+	// otherwise it will be faster to get checksum from metadata.
+	// return s.checksumFromMetadata(src)
+	rc, err := s.Read(src)
+	if err != nil {
+		return "", nil
+	}
+	defer rc.Close()
+
+	return validation.ChecksumReader(rc)
+}
+
+func (s *azblobStore) Write(dst *Blob, src io.Reader) error {
+	containerName := s.containerName(dst)
+	path := s.path(dst)
+	if err := s.createContainer(containerName); err != nil {
+		return err
+	}
+
+	containerURL := s.serviceURL.NewContainerURL(containerName)
+	blobURL := containerURL.NewBlockBlobURL(path)
+
+	_, err := azblob.UploadStreamToBlockBlob(context.Background(),
+		src,
+		blobURL,
+		azblob.UploadStreamToBlockBlobOptions{
+			BufferSize: 10 * 1024 * 1024, // 10M buffer size
+			MaxBuffers: 20,
+		})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *azblobStore) Exists(blob *Blob) bool {
+	checksum, err := s.Checksum(blob)
+	if err != nil {
+		return false
+	}
+
+	return checksum == blob.Checksum
+}
+
+func (s *azblobStore) NewBucketIterator(containerName string) (BucketIterator, error) {
+	destContainerName := s.destContainerName(containerName)
+	containerExists, err := s.doesContainerExist(destContainerName)
+	if err != nil {
+		return nil, err
+	}
+
+	if !containerExists {
+		return nil, errors.New("bucket does not exist")
+	}
+
+	containerUrl := s.serviceURL.NewContainerURL(destContainerName)
+
+	marker := azblob.Marker{}
+	listBlob, err := containerUrl.ListBlobsFlatSegment(context.Background(),
+		marker,
+		azblob.ListBlobsSegmentOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(listBlob.Segment.BlobItems) == 0 {
+		return &s3BucketIterator{}, nil
+	}
+
+	doneCh := make(chan struct{})
+	blobCh := make(chan *Blob)
+
+	iterator := &s3BucketIterator{
+		doneCh: doneCh,
+		blobCh: blobCh,
+	}
+
+	go func() {
+		for marker.NotDone() {
+			for _, blobInfo := range listBlob.Segment.BlobItems {
+				select {
+				case <-doneCh:
+					doneCh = nil
+					return
+				default:
+					blobCh <- &Blob{
+						Path: filepath.Join(containerName, blobInfo.Name),
+					}
+				}
+			}
+			marker = listBlob.NextMarker
+		}
+		close(blobCh)
+	}()
+
+	return iterator, nil
+}
+
+// helpers
+
+func (s *azblobStore) destContainerName(container string) string {
+	return s.containerMapping[container]
+}
+
+func (s *azblobStore) containerName(blob *Blob) string {
+	return s.destContainerName(blob.Path[:strings.Index(blob.Path, "/")])
+}
+
+func (s *azblobStore) doesContainerExist(containerName string) (bool, error) {
+	containers, err := s.listContainers()
+	if err != nil {
+		return false, err
+	}
+	return stringInArray(containers, containerName), nil
+}
+
+func (s *azblobStore) createContainer(containerName string) error {
+	containerURL := s.serviceURL.NewContainerURL(containerName)
+
+	_, err := containerURL.Create(context.Background(),
+		azblob.Metadata{},
+		azblob.PublicAccessNone)
+	if serr, ok := err.(azblob.StorageError); ok {
+		switch serr.ServiceCode() {
+		case azblob.ServiceCodeContainerAlreadyExists:
+		default:
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *azblobStore) listContainers() ([]string, error) {
+	var containers []string
+	for marker := (azblob.Marker{}); marker.NotDone(); {
+		l, err := s.serviceURL.ListContainersSegment(
+			context.Background(),
+			marker,
+			azblob.ListContainersSegmentOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		marker = l.NextMarker
+
+		for _, c := range l.ContainerItems {
+			containers = append(containers, c.Name)
+		}
+	}
+
+	return containers, nil
+}
+func (s *azblobStore) path(blob *Blob) string {
+	return blob.Path[(strings.Index(blob.Path, "/") + 1):]
+}
+
+func (s *azblobStore) checksumFromMetadata(src *Blob) (string, error) {
+	containerName := s.containerName(src)
+	path := s.path(src)
+
+	containerURL := s.serviceURL.NewContainerURL(containerName)
+
+	blobURL := containerURL.NewBlobURL(path)
+	r, err := blobURL.GetProperties(context.Background(), azblob.BlobAccessConditions{})
+	if err != nil {
+		return "", err
+	}
+	md5 := r.ContentMD5()
+
+	return hex.EncodeToString(md5), nil
+}
+
+func stringInArray(arr []string, str string) bool {
+	for _, a := range arr {
+		if a == str {
+			return true
+		}
+	}
+	return false
+}

--- a/blobstore/azblob_test.go
+++ b/blobstore/azblob_test.go
@@ -1,0 +1,102 @@
+package blobstore_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/Azure/azure-storage-blob-go/2018-03-28/azblob"
+	"github.com/pivotal-cf/goblob/blobstore"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("azblobStore", func() {
+	var (
+		cloudStorageEnpointsMap = map[string]string{
+			"AzureChinaCloud":   "core.chinacloudapi.cn",
+			"AzureCloud":        "core.windows.net",
+			"AzureGermanCloud":  "core.cloudapi.de",
+			"AzureUSGovernment": "core.usgovcloudapi.net",
+		}
+	)
+
+	accountName := os.Getenv("AZURE_STORAGE_ACCOUNT")
+	accountKey := os.Getenv("AZURE_STORAGE_ACCOUNT_KEY")
+	cloudName := os.Getenv("AZURE_CLOUD")
+	if os.Getenv("AZURE_CLOUD") == "" {
+		cloudName = "AzureCloud"
+	}
+	controlContainer := "some-buildpacks"
+
+	blobStore := blobstore.NewAzBlobStore(accountName, accountKey, cloudName, "some-buildpacks", "some-droplets", "some-packages", "some-resources")
+
+	credential := azblob.NewSharedKeyCredential(accountName, accountKey)
+	pipeline := azblob.NewPipeline(credential, azblob.PipelineOptions{})
+	primaryURL, _ := url.Parse(
+		fmt.Sprintf("https://%s.blob.%s", accountName, cloudStorageEnpointsMap[cloudName]))
+	serviceURL := azblob.NewServiceURL(*primaryURL, pipeline)
+
+	AfterSuite(func() {
+		containerURL := serviceURL.NewContainerURL(controlContainer)
+		_, _ = containerURL.Delete(context.Background(), azblob.ContainerAccessConditions{})
+	})
+
+	Describe("Name()", func() {
+		It("Should return the name", func() {
+			name := blobStore.Name()
+			Expect(name).Should(BeEquivalentTo("azure blob store"))
+		})
+	})
+
+	Describe("List()", func() {
+		It("Should return list of files", func() {
+			fileReader, err := os.Open("./s3_testdata/test.txt")
+			Expect(err).ShouldNot(HaveOccurred())
+			for _, path := range []string{"cc-buildpacks/aa/bb", "cc-buildpacks/aa/cc", "cc-buildpacks/aa/dd"} {
+				err := blobStore.Write(&blobstore.Blob{
+					Path: filepath.Join(path, "test.txt"),
+				}, fileReader)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+			blobs, err := blobStore.List()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(len(blobs)).Should(BeEquivalentTo(3))
+		})
+	})
+
+	Describe("Read()", func() {
+		It("Should read the file", func() {
+			fileReader, err := os.Open("./s3_testdata/test.txt")
+			Expect(err).ShouldNot(HaveOccurred())
+			writeErr := blobStore.Write(&blobstore.Blob{
+				Path: "cc-buildpacks/aa/bb/test.txt",
+			}, fileReader)
+			Expect(writeErr).ShouldNot(HaveOccurred())
+			reader, err := blobStore.Read(&blobstore.Blob{
+				Path: "cc-buildpacks/aa/bb/test.txt",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(reader).ShouldNot(BeNil())
+		})
+	})
+
+	Describe("Write()", func() {
+		It("Should write to azure blob store with correct checksum", func() {
+			reader, err := os.Open("./s3_testdata/test.txt")
+			Expect(err).ShouldNot(HaveOccurred())
+			blob := &blobstore.Blob{
+				Path: "cc-buildpacks/aa/bb/test.txt",
+			}
+			err = blobStore.Write(blob, reader)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			checksum, err := blobStore.Checksum(blob)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(checksum).Should(BeEquivalentTo("d8e8fca2dc0f896fd7cb4cb0031ba249"))
+		})
+	})
+})

--- a/commands/goblob.go
+++ b/commands/goblob.go
@@ -18,6 +18,7 @@ type GoblobCommand struct {
 	Version func() `command:"version" description:"Print version information and exit"`
 
 	Migrate MigrateCommand `command:"migrate" description:"Migrate blobs from one blobstore to another"`
+	MigrateToAzure MigrateToAzureBlobCommand `command:"migrate2azure" description:"Migrate blobs from NFS blobstore to Azure blobstore"`
 }
 
 var Goblob GoblobCommand

--- a/commands/migrate2azblob.go
+++ b/commands/migrate2azblob.go
@@ -1,0 +1,67 @@
+// Copyright 2017-Present Pivotal Software, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http:#www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+
+	"code.cloudfoundry.org/workpool"
+	"github.com/pivotal-cf/goblob"
+	"github.com/pivotal-cf/goblob/blobstore"
+)
+
+type MigrateToAzureBlobCommand struct {
+	ConcurrentUploads int      `long:"concurrent-uploads" env:"CONCURRENT_UPLOADS" default:"20"`
+	Exclusions        []string `long:"exclude" description:"blobstore directories to exclude, e.g. cc-resources"`
+
+	NFS struct {
+		Path string `long:"blobstore-path" env:"BLOBSTORE_PATH" description:"path to root of blobstore" default:"/var/vcap/store/shared"`
+	} `group:"NFS"`
+
+	AzStore struct {
+		AccountName          string `long:"azure-storage-account" env:"AZURE_STORAGE_ACCOUNT" description:"Azure storage account name"`
+		AccountKey           string `long:"azure-storage-account-key" env:"AZURE_STORAGE_ACCOUNT_KEY" description:"Azure storage account key"`
+		CloudName            string `long:"cloud-name" default:"AzureCloud" env:"AZURE_CLOUD" description:"cloud name, available names are: AzureCloud, AzureChinaCloud, AzureGermanCloud, AzureUSGovernment"`
+		BuildpacksBucketName string `long:"buildpacks-bucket-name" default:"cc-buildpacks" description:"name of bucket to store buildpacks in"`
+		DropletsBucketName   string `long:"droplets-bucket-name" default:"cc-droplets" description:"name of bucket to store droplets in"`
+		PackagesBucketName   string `long:"packages-bucket-name" default:"cc-packages" description:"name of bucket to store packages in"`
+		ResourcesBucketName  string `long:"resources-bucket-name" default:"cc-resources" description:"name of bucket to store resources in"`
+	} `group:"AzureBlob"`
+}
+
+func (c *MigrateToAzureBlobCommand) Execute([]string) error {
+	nfsStore := blobstore.NewNFS(c.NFS.Path)
+	azblobStore := blobstore.NewAzBlobStore(
+		c.AzStore.AccountName,
+		c.AzStore.AccountKey,
+		c.AzStore.CloudName,
+		c.AzStore.BuildpacksBucketName,
+		c.AzStore.DropletsBucketName,
+		c.AzStore.PackagesBucketName,
+		c.AzStore.ResourcesBucketName,
+	)
+
+	blobMigrator := goblob.NewBlobMigrator(azblobStore, nfsStore)
+	pool, err := workpool.NewWorkPool(c.ConcurrentUploads)
+	if err != nil {
+		return fmt.Errorf("error creating workpool: %s", err)
+	}
+
+	watcher := goblob.NewBlobstoreMigrationWatcher()
+
+	blobStoreMigrator := goblob.NewBlobstoreMigrator(pool, blobMigrator, c.Exclusions, watcher)
+
+	return blobStoreMigrator.Migrate(azblobStore, nfsStore)
+}


### PR DESCRIPTION
Usage example:
```
goblob migrate2azure --blobstore-path /var/vcap/store/shared \
  --azure-storage-account $storage_account_name \
  --azure-storage-account-key $storage_account_key \
  --cloud-name AzureCloud \
  --buildpacks-bucket-name cf-buildpacks \
  --droplets-bucket-name cf-droplets \
  --packages-bucket-name cf-packages \
  --resources-bucket-name cf-resources
```